### PR TITLE
Add ISubsystemsPlugin as a way to plugably create subsystems (DB-427)

### DIFF
--- a/src/EventStore.Plugins/Subsystems/ISubsystem.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystem.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventStore.Plugins.Subsystems;
+
+public interface ISubsystem {
+	IApplicationBuilder Configure(IApplicationBuilder builder);
+	IServiceCollection ConfigureServices(IServiceCollection services);
+	IEnumerable<Task> Start();
+	void Stop();
+}

--- a/src/EventStore.Plugins/Subsystems/ISubsystemFactory.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystemFactory.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Plugins.Subsystems;
+
+public interface ISubsystemFactory<TArg> {
+	ISubsystem Create(TArg arg);
+}

--- a/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace EventStore.Plugins.Subsystems;
+
+// A plugin that can create multiple subsystems.
+// A TArg is required to produce each subsystem from its respective factory.
+public interface ISubsystemsPlugin<TArg> {
+	string Name { get; }
+	string Version { get; }
+	string CommandLineName { get; }
+	IEnumerable<ISubsystemFactory<TArg>> GetSubsystemFactories(string configPath);
+}


### PR DESCRIPTION
- The plugin itself yields factories so that the subsystems themselves can be instantiated later (e.g. with StandardComponents once the buses have been created)
- The subsystem interface is essentially moved straight from the main repo but without Register(...). Instead we inject any required arguments in the factory
- We avoid exposing the bus machinary here (IPublisher, StandardComponents etc) and instead abstract them behind the generic type parameter TArg