### PR TITLE
Return an IReadOnlyList for simplicity (DB-427)

### DIFF
--- a/src/EventStore.Plugins/Subsystems/ISubsystem.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystem.cs
@@ -8,6 +8,6 @@ namespace EventStore.Plugins.Subsystems;
 public interface ISubsystem {
 	IApplicationBuilder Configure(IApplicationBuilder builder);
 	IServiceCollection ConfigureServices(IServiceCollection services);
-	IEnumerable<Task> Start();
+	IReadOnlyList<Task> Start();
 	void Stop();
 }

--- a/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
@@ -8,5 +8,5 @@ public interface ISubsystemsPlugin<TArg> {
 	string Name { get; }
 	string Version { get; }
 	string CommandLineName { get; }
-	IEnumerable<ISubsystemFactory<TArg>> GetSubsystemFactories(string configPath);
+	IReadOnlyList<ISubsystemFactory<TArg>> GetSubsystemFactories(string configPath);
 }


### PR DESCRIPTION
Otherwise some risk that the subsystem will use an iterator and something will enumerate it twice resulting potentially in parts of the subsystems startup routine unintentionally being run twice