### PR TITLE
Simplify subsystem API

### DIFF
--- a/src/EventStore.Plugins/Subsystems/ISubsystem.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystem.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace EventStore.Plugins.Subsystems;
 
 public interface ISubsystem {
+	string Name { get; }
 	IApplicationBuilder Configure(IApplicationBuilder builder);
 	IServiceCollection ConfigureServices(IServiceCollection services, IConfiguration configuration);
 	Task Start();

--- a/src/EventStore.Plugins/Subsystems/ISubsystemFactory.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystemFactory.cs
@@ -1,5 +1,0 @@
-﻿namespace EventStore.Plugins.Subsystems;
-
-public interface ISubsystemFactory {
-	ISubsystem Create();
-}

--- a/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystemsPlugin.cs
@@ -7,5 +7,5 @@ public interface ISubsystemsPlugin {
 	string Name { get; }
 	string Version { get; }
 	string CommandLineName { get; }
-	IReadOnlyList<ISubsystemFactory> GetSubsystemFactories(string configPath);
+	IReadOnlyList<ISubsystem> GetSubsystems();
 }


### PR DESCRIPTION
- No need to pass a path to configuration files. The IConfiguration is passed later
- No need for ISubsystemFactory now that there is no TArg to pass
- Add Subsystem name to distinguish them from each other