### PR TITLE
Drop targets for Net6 and Net7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
           8.0.x
     - name: Scan for Vulnerabilities
       shell: bash
@@ -36,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        framework: [net6.0, net7.0, net8.0]
+        framework: [net8.0]
         test: [".Tests"]
         configuration: [release]
         docker-tag: ['ci']
@@ -51,8 +49,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
           8.0.x
     - name: Compile
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
 
       - name: Get the version

--- a/src/EventStore.Plugins.Tests/EventStore.Plugins.Tests.csproj
+++ b/src/EventStore.Plugins.Tests/EventStore.Plugins.Tests.csproj
@@ -1,26 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+	</ItemGroup>
 
-    <ItemGroup>
-				<PackageReference Include="System.Net.Http" Version="4.3.4" />
-				<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-				<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Plugins\EventStore.Plugins.csproj" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\EventStore.Plugins\EventStore.Plugins.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="ConfigurationReaderTests\valid_node_config.yaml">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+	<ItemGroup>
+		<None Include="ConfigurationReaderTests\valid_node_config.yaml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 </Project>

--- a/src/EventStore.Plugins/EventStore.Plugins.csproj
+++ b/src/EventStore.Plugins/EventStore.Plugins.csproj
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+	<PropertyGroup>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64</Platforms>
 		<Nullable>disable</Nullable>
 		<NullableContextOptions>enable</NullableContextOptions>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup>
+	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>EventStore.Plugins</PackageId>
 		<Authors>Event Store Ltd</Authors>
@@ -17,12 +17,12 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Description>The interfaces required to create plugins for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.com/</Description>
 		<PackageReleaseNotes>https://eventstore.com/blog/release-notes/</PackageReleaseNotes>
-		<Copyright>Copyright 2012-2020 Event Store Ltd</Copyright>
+		<Copyright>Copyright 2012-2024 Event Store Ltd</Copyright>
 		<PackageTags>eventstore plugins</PackageTags>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="Serilog" Version="2.12.0" />
-	  <PackageReference Include="YamlDotNet" Version="12.0.1" />
+		<PackageReference Include="Serilog" Version="2.12.0" />
+		<PackageReference Include="YamlDotNet" Version="12.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
No need for them now, the only consumers of this are the main server and the plugins and they are all upgraded to Net8