### PR TITLE
Rename for clarity

### DIFF
--- a/src/EventStore.Plugins/Authentication/AuthenticationRequest.cs
+++ b/src/EventStore.Plugins/Authentication/AuthenticationRequest.cs
@@ -21,9 +21,9 @@ namespace EventStore.Plugins.Authentication {
 		public readonly string SuppliedPassword;
 
 		/// <summary>
-		///     Whether or not a client certificate was supplied with the request
+		///     Whether or not a valid client certificate was supplied with the request
 		/// </summary>
-		public readonly bool HasSuppliedClientCertificate;
+		public readonly bool HasValidClientCertificate;
 
 		/// <summary>
 		///		All supplied authentication tokens for the request
@@ -38,7 +38,7 @@ namespace EventStore.Plugins.Authentication {
 			Tokens = tokens;
 			Name = GetToken("uid");
 			SuppliedPassword = GetToken("pwd");
-			HasSuppliedClientCertificate = GetToken("client-certificate") != null;
+			HasValidClientCertificate = GetToken("client-certificate") != null;
 		}
 
 		/// <summary>

--- a/src/EventStore.Plugins/Authentication/HttpAuthenticationRequest.cs
+++ b/src/EventStore.Plugins/Authentication/HttpAuthenticationRequest.cs
@@ -32,7 +32,7 @@ public class HttpAuthenticationRequest : AuthenticationRequest {
 		}) {
 	}
 
-	public static HttpAuthenticationRequest CreateWithCertificate(HttpContext context, string name, X509Certificate2 clientCertificate) =>
+	public static HttpAuthenticationRequest CreateWithValidCertificate(HttpContext context, string name, X509Certificate2 clientCertificate) =>
 		new(context, new Dictionary<string, string> {
 			["uid"] = name,
 			["client-certificate"] = clientCertificate.ExportCertificatePem(),


### PR DESCRIPTION
Unlike the password which hasn't been validated, it is important that the certificate is only supplied if it is already known to be valid