### PR TITLE
Add method to collect telemetry from MD5 plugin

### DIFF
--- a/src/EventStore.Plugins/MD5/IMD5Plugin.cs
+++ b/src/EventStore.Plugins/MD5/IMD5Plugin.cs
@@ -1,10 +1,15 @@
-﻿namespace EventStore.Plugins.MD5;
+﻿using System;
+using System.Text.Json.Nodes;
+
+namespace EventStore.Plugins.MD5;
 
 public interface IMD5Plugin {
 	string Name { get; }
 	string Version { get; }
 
 	string CommandLineName { get; }
+
+	void CollectTelemetry(Action<string, JsonNode> reply);
 
 	/// <summary>
 	///     Creates an MD5 provider factory for the MD5 plugin

--- a/src/EventStore.Plugins/Subsystems/ISubsystem.cs
+++ b/src/EventStore.Plugins/Subsystems/ISubsystem.cs
@@ -11,7 +11,7 @@ public interface ISubsystem {
 	string Name { get; }
 	IApplicationBuilder Configure(IApplicationBuilder builder);
 	IServiceCollection ConfigureServices(IServiceCollection services, IConfiguration configuration);
-	void CollectTelemetry(Action<string, JsonNode> collect);
+	void CollectTelemetry(Action<string, JsonNode> reply);
 	Task Start();
 	Task Stop();
 }


### PR DESCRIPTION
Added: Add method to collect telemetry from MD5 plugin

https://linear.app/eventstore/issue/DB-736/other-plugins-to-expose-the-required-telemetry

Apart from this, update the argument name (collect -> reply) for the collectTelemetry for clearer naming.

