### PR TITLE
[DBX-50] Always store Partials in Snapshots

### DIFF
--- a/src/EventStore.Plugins/Plugin.cs
+++ b/src/EventStore.Plugins/Plugin.cs
@@ -30,6 +30,7 @@ public abstract class Plugin : IPlugableComponent, IDisposable {
 
 		Name = name ?? pluginType.Name
 			.Replace("Plugin", "", OrdinalIgnoreCase)
+			.Replace("Provider", "", OrdinalIgnoreCase)
 			.Replace("Component", "", OrdinalIgnoreCase)
 			.Replace("Subsystems", "", OrdinalIgnoreCase)
 			.Replace("Subsystem", "", OrdinalIgnoreCase);

--- a/test/EventStore.Plugins.Tests/Diagnostics/PluginDiagnosticsDataCollectorTests.cs
+++ b/test/EventStore.Plugins.Tests/Diagnostics/PluginDiagnosticsDataCollectorTests.cs
@@ -13,8 +13,9 @@ public class PluginDiagnosticsDataCollectorTests {
 
 		plugin.PublishDiagnosticsData(new() { ["enabled"] = plugin.Enabled });
 
-		sut.CollectedEvents(plugin.DiagnosticsName).Should().ContainSingle().Which
-			.Data["enabled"].Should().Be(plugin.Enabled);
+		var diagnosticsData = sut.CollectedEvents(plugin.DiagnosticsName).Should().ContainSingle().Which;
+		diagnosticsData.Data["enabled"].Should().Be(plugin.Enabled);
+		diagnosticsData.CollectionMode.Should().Be(PluginDiagnosticsDataCollectionMode.Snapshot);
 	}
 	
 	[Fact]


### PR DESCRIPTION
If a snapshot doesn't exist, turn the partial into a snapshot

Otherwise when we collect the snapshot later, it isn't there