### PR TITLE
[ESDB-159-3] Add support for checking Entitlements

### DIFF
--- a/src/EventStore.Plugins/EventStore.Plugins.csproj
+++ b/src/EventStore.Plugins/EventStore.Plugins.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
 		<PackageReference Include="YamlDotNet" Version="15.1.4" />
 		<PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+		<PackageReference Include="System.Reactive" Version="6.0.1" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/EventStore.Plugins/Licensing/ILicenseService.cs
+++ b/src/EventStore.Plugins/Licensing/ILicenseService.cs
@@ -1,0 +1,15 @@
+﻿namespace EventStore.Plugins.Licensing;
+
+// Allows plugins to access the current license, get updates to it, and reject a license
+// if it is missing entitlements
+public interface ILicenseService {
+	// For checking that the license service itself is authentic
+	License SelfLicense { get; }
+
+	License? CurrentLicense { get; }
+
+	// The current license and updates to it
+	IObservable<License> Licenses { get; }
+
+	void RejectLicense(Exception ex);
+}

--- a/src/EventStore.Plugins/PluginLicenseException.cs
+++ b/src/EventStore.Plugins/PluginLicenseException.cs
@@ -1,8 +1,14 @@
 namespace EventStore.Plugins;
 
-public class PluginLicenseException(string pluginName) : Exception(
+public class PluginLicenseException(string pluginName, Exception? inner = null) : Exception(
 	$"A license is required to use the {pluginName} plugin, but was not found. " +
-	"Please obtain a license or disable the plugin."
+	"Please obtain a license or disable the plugin.",
+	inner
 ) {
+	public string PluginName { get; } = pluginName;
+}
+
+public class PluginLicenseEntitlementException(string pluginName, string entitlement) : Exception(
+	$"{pluginName} plugin requires the {entitlement} entitlement. Please contact EventStore support.") {
 	public string PluginName { get; } = pluginName;
 }

--- a/src/EventStore.Plugins/SubsystemsPlugin.cs
+++ b/src/EventStore.Plugins/SubsystemsPlugin.cs
@@ -21,6 +21,7 @@ public abstract class SubsystemsPlugin : Plugin, ISubsystem, ISubsystemsPlugin {
 	protected SubsystemsPlugin(
 		string? name = null, string? version = null,
 		string? licensePublicKey = null,
+		string[]? requiredEntitlements = null,
 		string? commandLineName = null,
 		string? diagnosticsName = null,
 		params KeyValuePair<string, object?>[] diagnosticsTags
@@ -28,6 +29,7 @@ public abstract class SubsystemsPlugin : Plugin, ISubsystem, ISubsystemsPlugin {
 		Name = name,
 		Version = version,
 		LicensePublicKey = licensePublicKey,
+		RequiredEntitlements = requiredEntitlements,
 		DiagnosticsName = diagnosticsName,
 		DiagnosticsTags = diagnosticsTags,
 		CommandLineName = commandLineName

--- a/test/EventStore.Plugins.Tests/Licensing/LicenseTests.cs
+++ b/test/EventStore.Plugins.Tests/Licensing/LicenseTests.cs
@@ -16,15 +16,19 @@ public class LicenseTests {
 		var (publicKey, privateKey) = CreateKeyPair();
 
 		var license = await License.CreateAsync(publicKey, privateKey, new Dictionary<string, object> {
-			{ "foo", "bar" }
+			{ "foo", "bar" },
+			{ "my_entitlement", "true" },
 		});
 
 		// check repeatedly because of https://github.com/dotnet/runtime/issues/43087
-		(await license.IsValidAsync(publicKey)).Should().BeTrue();
-		(await license.IsValidAsync(publicKey)).Should().BeTrue();
-		(await license.IsValidAsync(publicKey)).Should().BeTrue();
+		(await license.ValidateAsync(publicKey)).Should().BeTrue();
+		(await license.ValidateAsync(publicKey)).Should().BeTrue();
+		(await license.ValidateAsync(publicKey)).Should().BeTrue();
 
 		license.Token.Claims.First(c => c.Type == "foo").Value.Should().Be("bar");
+		license.HasEntitlement("my_entitlement").Should().BeTrue();
+		license.HasEntitlements(["my_entitlement", "missing_entitlement"], out var missing).Should().BeFalse();
+		missing.Should().Be("missing_entitlement");
 	}
 
 	[Fact]
@@ -36,7 +40,7 @@ public class LicenseTests {
 			{ "foo", "bar" }
 		});
 
-		(await license.IsValidAsync(publicKey2)).Should().BeFalse();
+		(await license.ValidateAsync(publicKey2)).Should().BeFalse();
 	}
 
 	[Fact]


### PR DESCRIPTION
Also do not expect to find a License in the DI. Putting the license in the DI involved doing some sync over async and also meant that the licence couldn't change later (say, if it became in valid).

Instead we now find a ILicenseService in the DI which provides us with the current license and an observable of license updates. Also provides a method for the plugins to reject a license if it doesn't have sufficient entitlements