### PR TITLE
Simplify licensing signing key plumbing

### DIFF
--- a/src/EventStore.Plugins/Authentication/AuthenticationProviderBase.cs
+++ b/src/EventStore.Plugins/Authentication/AuthenticationProviderBase.cs
@@ -11,7 +11,6 @@ public abstract class AuthenticationProviderBase(PluginOptions options) : Plugin
 		string? version = null,
 		string? licensePublicKey = null,
 		string[]? requiredEntitlements = null,
-		Action<Exception>? onLicenseException = null,
 		string? diagnosticsName = null,
 		params KeyValuePair<string, object?>[] diagnosticsTags
 	) : this(new() {
@@ -19,7 +18,6 @@ public abstract class AuthenticationProviderBase(PluginOptions options) : Plugin
 		Version = version,
 		LicensePublicKey = licensePublicKey,
 		RequiredEntitlements = requiredEntitlements,
-		OnLicenseException = onLicenseException,
 		DiagnosticsName = diagnosticsName,
 		DiagnosticsTags = diagnosticsTags
 	}) { }

--- a/src/EventStore.Plugins/Authorization/AuthorizationProviderBase.cs
+++ b/src/EventStore.Plugins/Authorization/AuthorizationProviderBase.cs
@@ -11,7 +11,6 @@ public abstract class AuthorizationProviderBase(PluginOptions options) : Plugin(
 		string? version = null,
 		string? licensePublicKey = null,
 		string[]? requiredEntitlements = null,
-		Action<Exception>? onLicenseException = null,
 		string? diagnosticsName = null,
 		params KeyValuePair<string, object?>[] diagnosticsTags
 	) : this(new() {
@@ -19,7 +18,6 @@ public abstract class AuthorizationProviderBase(PluginOptions options) : Plugin(
 		Version = version,
 		LicensePublicKey = licensePublicKey,
 		RequiredEntitlements = requiredEntitlements,
-		OnLicenseException = onLicenseException,
 		DiagnosticsName = diagnosticsName,
 		DiagnosticsTags = diagnosticsTags
 	}) { }

--- a/src/EventStore.Plugins/IPlugableComponent.cs
+++ b/src/EventStore.Plugins/IPlugableComponent.cs
@@ -39,7 +39,7 @@ public interface IPlugableComponent {
 	/// <summary>
 	///		The public key used for licensing.
 	/// </summary>
-	string? LicensePublicKey { get; }
+	string LicensePublicKey { get; }
 	
 	/// <summary>
 	///     Configures the services using the provided IServiceCollection and IConfiguration.

--- a/src/EventStore.Plugins/Licensing/LicenseConstants.cs
+++ b/src/EventStore.Plugins/Licensing/LicenseConstants.cs
@@ -4,5 +4,8 @@
 namespace EventStore.Plugins.Licensing;
 
 public static class LicenseConstants {
+	public const int RsaMinimumKeySizeInBits = 2048;
 	public const string LicensePublicKey = "MEgCQQDGtRXIWmeJqkdpQryJdKBFVvLaMNHFkDcVXSoaDzg1ahrtCrAgwYpARAvGyFs0bcwYJZaZSt9aNwpgkAPOPQM5AgMBAAE=";
+	// not actually private (here it is in the source and binaries). circumventing the license mechanism is against the ESLv2 license agreement.
+	internal const string LicensePrivateKey = "MIIBPAIBAAJBAMa1FchaZ4mqR2lCvIl0oEVW8tow0cWQNxVdKhoPODVqGu0KsCDBikBEC8bIWzRtzBgllplK31o3CmCQA849AzkCAwEAAQJBALFULYpNU5UBhxUi34pzsAvxWmzpoGsFFoNUTxxOdMUExvprTltFKQ/hDAyNsc8oUg0AdBzt/jDzTce/W0WerHkCIQDq6SIeuUjWqGOG/+thcLJSj0jnNJ7NFJTPZDqaiocQDwIhANiL53qkAlWIg0uPlxARDtGI/bx5irIBn9Hed81WrnA3AiEApL4U4KkebPQwwHdwEqjfVkkIXqUnjTmW1w86jjECYX8CIQCa/Hcupdgt08j0+c6K50qN2diRXwRPpy32DZ39T38GPQIgSBL+EU/YRy6nwsqLLB+6+qtMd0s1T5kpI3l9VyNM3Uc=";
 }

--- a/src/EventStore.Plugins/Licensing/LicenseMonitor.cs
+++ b/src/EventStore.Plugins/Licensing/LicenseMonitor.cs
@@ -14,9 +14,10 @@ public static class LicenseMonitor {
 		ILicenseService licenseService,
 		Action<Exception> onLicenseException,
 		ILogger logger,
-		string licensePublicKey = LicenseConstants.LicensePublicKey,
+		string? licensePublicKey = null,
 		Action<int>? onCriticalError = null) {
 
+		licensePublicKey ??= LicenseConstants.LicensePublicKey;
 		onCriticalError ??= Environment.Exit;
 
 		// authenticate the license service itself so that we can trust it to

--- a/src/EventStore.Plugins/SubsystemsPlugin.cs
+++ b/src/EventStore.Plugins/SubsystemsPlugin.cs
@@ -25,7 +25,6 @@ public abstract class SubsystemsPlugin : Plugin, ISubsystem, ISubsystemsPlugin {
 		string? name = null, string? version = null,
 		string? licensePublicKey = null,
 		string[]? requiredEntitlements = null,
-		Action<Exception>? onLicenseException = null,
 		string? commandLineName = null,
 		string? diagnosticsName = null,
 		params KeyValuePair<string, object?>[] diagnosticsTags
@@ -34,7 +33,6 @@ public abstract class SubsystemsPlugin : Plugin, ISubsystem, ISubsystemsPlugin {
 		Version = version,
 		LicensePublicKey = licensePublicKey,
 		RequiredEntitlements = requiredEntitlements,
-		OnLicenseException = onLicenseException,
 		DiagnosticsName = diagnosticsName,
 		DiagnosticsTags = diagnosticsTags,
 		CommandLineName = commandLineName

--- a/test/EventStore.Plugins.Tests/Licensing/LicenseMonitorTests.cs
+++ b/test/EventStore.Plugins.Tests/Licensing/LicenseMonitorTests.cs
@@ -22,7 +22,6 @@ public class LicenseMonitorTests {
 			licenseService: licenseService,
 			onLicenseException: ex => licenseException = ex,
 			logger: new FakeLogger(),
-			licensePublicKey: licenseService.PublicKey,
 			onCriticalError: _ => criticalError = true);
 
 		licenseException.Should().BeNull();
@@ -44,7 +43,6 @@ public class LicenseMonitorTests {
 			licenseService: licenseService,
 			onLicenseException: ex => licenseException = ex,
 			logger: new FakeLogger(),
-			licensePublicKey: licenseService.PublicKey,
 			onCriticalError: _ => criticalError = true);
 
 		licenseException.Should().BeNull();
@@ -66,7 +64,6 @@ public class LicenseMonitorTests {
 			licenseService: licenseService,
 			onLicenseException: ex => licenseException = ex,
 			logger: new FakeLogger(),
-			licensePublicKey: licenseService.PublicKey,
 			onCriticalError: _ => criticalError = true);
 
 		licenseException.Should().BeOfType<LicenseEntitlementException>()
@@ -88,7 +85,6 @@ public class LicenseMonitorTests {
 			licenseService: licenseService,
 			onLicenseException: ex => licenseException = ex,
 			logger: new FakeLogger(),
-			licensePublicKey: licenseService.PublicKey,
 			onCriticalError: _ => criticalError = true);
 
 		licenseException.Should().BeOfType<LicenseException>();


### PR DESCRIPTION
- Bake keys in lower down so we don't have to plumb them around by default. This is more appropriate than it used to be now that we have the ESLv2 license
- Overriding is still possible
- Plugin monitoring of license is enabled according to the presence of RequiredEntitlements rather than the public key
- Change OnLicenseException to be abstract member (it was impractical to use before)